### PR TITLE
Add adiabatic evolution, parameter dependence interface for Hamiltonian

### DIFF
--- a/examples/02_quadratic_potential.py
+++ b/examples/02_quadratic_potential.py
@@ -18,12 +18,15 @@ H = Hamiltonian(N, L, m)
 
 # Set potential
 x = np.linspace(-L[0]/2, L[0]/2, N[0])
-k = 200
-V = 1/2*k*x**2
-H.set_static_potential(V)
+
+def V(t):
+    k = 200
+    return 1/2*(k+t)*x**2
+H.set_potential(V)
+
 
 # Solve the system
-energies, states = H.eigen(n)
+energies, states = H.eigen(n,t=1000)
 
 # Plot results
 from matplotlib import pyplot as plt

--- a/examples/03_2D_potential.py
+++ b/examples/03_2D_potential.py
@@ -23,8 +23,8 @@ V[
     N[1] // 2 - N[1] // 5 : N[1] // 2 + N[1] // 5
 ] = 0
 
-H.set_static_potential(V)
-
+H.set_potential(V)
+print(V)
 # Solve the system
 energies, states = H.eigen(n)
 

--- a/examples/04_adiabatic_evolution.py
+++ b/examples/04_adiabatic_evolution.py
@@ -1,0 +1,61 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.animation import FuncAnimation
+
+from scipy.special import expit
+from qm_sim.hamiltonian import Hamiltonian
+from qm_sim.nature_constants import m_e, e_0
+
+import numpy as np
+
+s = 200
+N = (s, s)              # Discretisation point count
+L = (8e-9, 8e-9)        # System size in meters
+m = m_e                 # Mass of the particle, here chosen as electron mass
+n = 4                   # The amount of eigenstates to find
+steps = 100
+
+
+H = Hamiltonian(N, L, m)
+
+# Set potential. Here, a square well is used, with dV = 0.15 eV
+x,y = np.linspace(-L[0]/2,L[0]/2, s), np.linspace(-L[0]/2,L[0]/2, s)
+X, Y = np.meshgrid(x,y)
+
+# Smoothed rectangular time-dependent potential, assymetric to avoid degeneracy 
+def V(t):
+    a = 0.15*e_0*expit(5*10**9*(X-2e-9 + 1e-11*t)) + 0.15*e_0*expit(-5*10**9*(X+2e-9-1e-11*t))
+    b = 0.15*e_0*expit(5*10**9*(Y-2.5e-9 - 1e-11*t)) + 0.15*e_0*expit(-5*10**9*(Y+2.5e-9+1e-11*t))
+    return np.where(a+b>0.15*e_0,0.15*e_0,a+b)
+
+H.set_potential(V)
+
+# Solve the system
+energies, states = H.eigen(n)
+# Choose energy to follow
+E = energies[1]
+
+# Evolve adiabatically
+Energies, psi = H.adiabatic_evolution(E_n=E, t0=0, dt=1, steps=steps)
+
+# Create animation
+fig, (ax, ax2) = plt.subplots(1,2)
+im = ax.matshow(psi[:,:,0]**2)
+im2 = ax2.matshow(V(0).T)
+ims = [im,im2]
+
+def init():
+    im.set_data(psi[:,:,0]**2)
+    im2.set_data(V(0).T)
+    return im
+
+def update(j):
+    ims[0].set_data(psi[:,:,j]**2)
+    ims[1].set_data(V(j).T)
+    return ims
+
+anim = FuncAnimation(fig, func=update, init_func=init, frames=steps, interval=50, blit=False, repeat = True, repeat_delay = 1000)
+plt.show()
+
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 dependencies = [
     "numpy>=1.23",
     "scipy>=1.10",
+    "tqdm>=4.64.1"
 ]
 
 [project.urls]

--- a/src/qm_sim/hamiltonian.py
+++ b/src/qm_sim/hamiltonian.py
@@ -2,6 +2,8 @@
 import numpy as np
 from scipy.sparse import dia_matrix
 from scipy.sparse.linalg import eigsh
+from typing import Callable
+from tqdm import tqdm
 
 from qm_sim import nature_constants as const
 from qm_sim import finite_difference
@@ -37,7 +39,7 @@ class Hamiltonian:
         self.L = L
         self._dim = len(N)
         self.delta = [Li / Ni for Li, Ni in zip(L, N)]
-        
+
         # index of the 0-offset.
         # Set in _get_fd_matrix
         self._centerline_index = None
@@ -71,13 +73,77 @@ class Hamiltonian:
         self.mat.data *= h0
 
         # No potential by default
-        self.V0 = 0
+        self.V = np.zeros(shape = N)
+        self.__V_timedep = False
 
 
-    def set_static_potential(self, V0: np.ndarray):
-        self.V0 = V0
-        self.mat.data[self._centerline_index, :] += V0.flatten()
-        self._default_data = self.mat.data.copy()
+    def set_potential(self, V: np.ndarray | Callable[[float], np.ndarray]):
+        """Set a (potentially time dependent) potential for the QM-system's Hamiltonian
+        
+        Args: 
+            V (np.ndarray | Callable[[float], np.ndarray]):
+                The energetic value of the potential at a given point associated with given array indices,
+                if callable, the call variable will represent a changable parameter (usually time) with a 
+                return type identical to the static case where V is an np.ndarray
+        """
+        # Todo: Set up tests to check if V is valid
+        if callable(V):
+            self.__V_timedep = True
+        else:
+            self.__V_timedep = False
+        self.V = V
+
+
+    def get_V(self, t: float = 0) -> np.ndarray:
+        if self.__V_timedep:
+            return self.V(t)
+        return self.V
+
+
+    def adiabatic_evolution(self, E_n: float, t0: float, dt : float, steps: int) -> tuple[np.ndarray, np.ndarray]:
+        """Adiabatically evolve an eigenstate with a slowly varying time-dependent potential with
+        energy (close to) E_n using the Adiabatic approximation. 
+        https://en.wikipedia.org/wiki/Adiabatic_theorem
+
+        Note: This is only valid given that the adiabatic theorem holds, ie. no degeneracy and a gap between 
+        eigenvalues. Current implementation assumes this holds and does not check if it does (yet?). 
+        There is no mathematical guarantee (yet?) that the iterative solver will "hug" the correct eigenvector
+        at every step, but it should be good if V varies smoothly enough and dt is small enough. 
+        
+        Args:
+            E_n (float): 
+                The Eigenvalue for you want to adiabatically evolve 
+            t_0 (float): 
+                Starting time for time-evolution
+            dt (float): 
+                The (small) time parameter increment used to update the eigenstate temporally
+            steps (int): 
+                Number of increments.
+        
+        returns:
+            tuple[np.ndarray(shape = steps), np.ndarray(shape = (N, steps))]:
+                (E(t), Psi(t)), Time evolution of the eigenstate.
+        """
+        if not self.__V_timedep:
+            raise RuntimeError("Hamiltonian needs to be time-dependent for method to be meaingful.")
+        
+        Psi_t = np.empty(shape = (self.N[0],self.N[1],steps+1))
+        En_t = np.empty(steps+1)
+        
+        for i in tqdm(range(steps+1)):
+            H = self.mat.copy()
+            H.data[self._centerline_index, :] += self.V(t0+i*dt).flatten()
+            
+            En_t[i], psi = eigsh(
+                A=H,
+                k=1,
+                # smartly condition eigsolver to "hug" the single eigenvalue solution; eigenvector and eigenvalue should be
+                # far closer to the previous one than any other if the adiabatic theorem is fulfilled
+                sigma=En_t[i-1] if i != 0 else E_n,
+                v0=Psi_t[:,:,i-1] if i != 0 else np.ones(shape = self.N).flatten()
+            )
+            Psi_t[:,:,i] = psi[:].reshape(self.N[::-1]).T
+        return En_t, Psi_t
 
 
     def __add__(self, other: np.ndarray) -> dia_matrix:
@@ -93,20 +159,33 @@ class Hamiltonian:
     def asarray(self) -> np.array:
         return self.mat.toarray()
 
-    def eigen(self, n: int) -> tuple[np.ndarray, np.ndarray]:
+
+    def eigen(self, n: int, t: float = 0) -> tuple[np.ndarray, np.ndarray]:
         """Calculate the n smallest eigenenergies and the corresponding eigenstates of the hamiltonian
 
         Args:
             n (int): 
                 Amount of eigenenergies/states to output
-
+            t (float):
+                (Optional) If the potential is time-dependent, solves the Time-independent Schrödinger eq. as if it was frozen at time t.
+                Does nothing if potential is time-independent
         Returns:
             np.ndarray:
                 Eigenenergies, shape (n,)
             np.ndarray:
                 Normalised eigenstates, shape (n, *N) for a system with shape N
         """
-        E, psi = eigsh(self.mat, k=n, which="SA")
+        # set initial conditions
+        if self.__V_timedep:
+            Vt = self.V(t)
+        else:
+            Vt = self.V
+
+        H = self.mat.copy()
+        H.data[self._centerline_index, :] += Vt.flatten()
+        self._default_data = H.copy()
+
+        E, psi = eigsh(H, k=n, which="SA")
         psi = np.array([psi[:, i].reshape(self.N[::-1]).T for i in range(n)])
 
         # calculate normalisation factor
@@ -118,5 +197,5 @@ class Hamiltonian:
         # normalise
         for i in range(n):
             psi[i] /= nf[i]**0.5
-        
+
         return E, psi

--- a/src/qm_sim/temporal_hamiltonian/__init__.py
+++ b/src/qm_sim/temporal_hamiltonian/__init__.py
@@ -38,7 +38,7 @@ def temporal_hamiltonian(H0: Hamiltonian, Vt: Callable[[float], np.ndarray],
                     - leapfrog
                     - forward-euler
                     - backward-euler
-                Defaults to cranc-nicholson
+                Defaults to crank-nicholson
         """
 
         # raises ValueError if scheme is not found

--- a/src/qm_sim/temporal_hamiltonian/base.py
+++ b/src/qm_sim/temporal_hamiltonian/base.py
@@ -36,6 +36,8 @@ class BaseTemporalHamiltonian(ABC):
 
         self.H0 = H0
         self.Vt = Vt
+        # Since there is no reason for original H to not be time dep
+        self.H0.set_potential(Vt)
         
         if dt is None:
             self.dt = self._get_dt()
@@ -77,8 +79,8 @@ class BaseTemporalHamiltonian(ABC):
         # TODO: perform the vN analysis for each scheme
         # (i.e. make this func abstract)
         # NOTE: this assumes the temporal part is at most 4x the static part
-        V_max = np.max(self.H0.V0 * 4)
-        V_min = np.min(self.H0.V0 * 4)
+        V_max = np.max(self.H0.get_V() * 4)
+        V_min = np.min(self.H0.get_V() * 4)
 
         E_max = max(
             abs(V_min),
@@ -108,10 +110,3 @@ class BaseTemporalHamiltonian(ABC):
     
     def get_t(self) -> np.ndarray:
         return np.array(self.t)
-    
-    def get_Vt(self) -> np.ndarray:
-        return np.array(self.V)
-
-    def get_V(self) -> np.ndarray:
-        Vt = np.array(self.V)
-        return self.H0.V0 + Vt


### PR DESCRIPTION
The code has been tested at my side and seems to work, see example 04

The solver seems to give madly different results for the eigenvectors when you perturb one of the N-values (ie. 199, 200), any ideas if this is physically/mathematically feasable or just some numerical instability?

One troublesome part is that the current adiabatic method doesnt seem to be able to capture dynamical phase change since (complex) eigenvectors are unique only up to a complex factor, which is relevant if any geometrical phase factor is to be explored computationally. The geometrical phase may be computable in some other way, but I have no current idea for how to achieve this. Some interesting reading on this that actually mentions this challenge is can be found here: https://iopscience.iop.org/article/10.1088/0953-8984/12/9/201/meta

This makes the current implementation slightly uninteresting but I think it can be somewhat interesting at the least
