### PR TITLE
Eigen speedup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,11 @@ Python library for simulation of quantum mechanical systems.
 ## Features 
 - 1D and 2D systems
 - Choice of finite difference scheme
-- Stationary solutions
+- Stationary and temporal solutions
 
 ## Planned features
 - Boundary conditions
 - 3D systems
-- Temporal simulation
-- Time-variant potentials
 - Transfer matrix for transmission ect.
 - Testing
 
@@ -40,8 +38,8 @@ TL;DR:
 - Python 3.10 or above
 
 ### Setup
-1. Clone and open the repo in VS Code
+1. Clone the repo recursively and open the repo in VS Code. If not cloned recursively, initialize the submodules with `git submodule update --init`
 2. Press f1, and run `Python: Create Environment`. Select `.venv`
-3. In the terminal, run `.venv\Scripts\activate` on Windows, or `source .venv/bin/activate` on Unix
-4. In the same terminal, run `pip install -e .` to install the current directory in an editable state
-5. To run tests, run `pip install pytest` in the terminal, press f1 and run `Python: Configure Tests`. Choose `pytest`
+3. Open a new terminal, which should automatically use the virtual environment. If not, run `.venv\Scripts\activate` on Windows, or `source .venv/bin/activate` on Unix
+4. In the same terminal, run `pip install -e .[test]` to install the current directory in an editable state, and the testing utility Pytest
+5. To run tests, press f1 and run `Python: Configure Tests`. Choose `pytest`. Run tests in the testing menu

--- a/src/qm_sim/cpp/eigen/__init__.py
+++ b/src/qm_sim/cpp/eigen/__init__.py
@@ -1,4 +1,4 @@
 try:
     from .eigen_wrapper import *
 except ImportError:
-    print("Warning: Eigen C++ module not found")
+    print("Warning: eigen_wrapper C++ module not found")

--- a/src/qm_sim/cpp/eigen/scripts/generate_init.py
+++ b/src/qm_sim/cpp/eigen/scripts/generate_init.py
@@ -9,7 +9,7 @@ import sys, pathlib
 def main(module_name: str):
     path = pathlib.Path(__file__).parent.parent
     with open(path / "__init__.py", "w") as file:
-        file.write(f""""try:
+        file.write(f"""try:
     from .{module_name} import *
 except ImportError:
     print("Warning: {module_name} C++ module not found")""")

--- a/src/qm_sim/hamiltonian/eigsh.py
+++ b/src/qm_sim/hamiltonian/eigsh.py
@@ -1,0 +1,25 @@
+"""
+
+Use the scipy backend eigen solver to skip some overhead
+
+"""
+from scipy._lib._threadsafety import ReentrancyLock
+from scipy.sparse.linalg._eigen.arpack.arpack import _SymmetricArpackParams, _UnsymmetricArpackParams
+
+
+def eigsh(A_OP, n, dtype, k=6, sigma=None, which='LA', v0=None,
+          ncv=None, maxiter=None, tol=0, return_eigenvectors=True,
+          ):
+    mode = 1
+    M_matvec = None
+    Minv_matvec = None
+    params = _SymmetricArpackParams(n, k, dtype.char, A_OP, mode,
+                                    M_matvec, Minv_matvec, sigma,
+                                    ncv, v0, maxiter, which, tol)
+
+    with ReentrancyLock("Nested calls to eigs/eighs not allowed: "
+        "ARPACK is not re-entrant"):
+        while not params.converged:
+            params.iterate()
+
+        return params.extract(return_eigenvectors)    

--- a/src/qm_sim/hamiltonian/eigsh.py
+++ b/src/qm_sim/hamiltonian/eigsh.py
@@ -4,7 +4,7 @@ Use the scipy backend eigen solver to skip some overhead
 
 """
 from scipy._lib._threadsafety import ReentrancyLock
-from scipy.sparse.linalg._eigen.arpack.arpack import _SymmetricArpackParams, _UnsymmetricArpackParams
+from scipy.sparse.linalg._eigen.arpack.arpack import _SymmetricArpackParams
 
 
 def eigsh(A_OP, n, dtype, k=6, sigma=None, which='LA', v0=None,


### PR DESCRIPTION
Bypass some overhead in scipy to calculate eigenvalues/vectors a couple percent faster

Also fixes a typo in the cpp `__init__.py` generation