### PR TITLE
Crank-Nicolson

### DIFF
--- a/src/qm_sim/hamiltonian/__init__.py
+++ b/src/qm_sim/hamiltonian/__init__.py
@@ -187,7 +187,7 @@ class Hamiltonian:
 
     def temporal_evolution(self, t_final: float, dt: float = None, 
         psi_0: np.ndarray = None) -> tuple[np.ndarray, np.ndarray]:
-        return self._temporal_solver(self, psi_0, dt).iterate(t_final, dt)
+        return self._temporal_solver(self, psi_0).iterate(t_final, dt)
     temporal_evolution.__doc__ = TemporalDerivative.iterate.__doc__
     
     def _get_eigen(self, n: int, t: float, **kwargs) -> tuple[np.ndarray, np.ndarray]:

--- a/src/qm_sim/hamiltonian/temporal_derivative/base.py
+++ b/src/qm_sim/hamiltonian/temporal_derivative/base.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 
 import numpy as np
+from tqdm import tqdm
 
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
@@ -46,6 +47,15 @@ class BaseTemporalDerivative(ABC):
         if v_0 is None:
             v_0 = self._get_initial_condition()
         self.v_0 = v_0
+
+    def tqdm(self, t: float) -> tqdm:
+        pbar = tqdm(desc=self.name + " solver", total=t, disable=not self.H.verbose)
+        pbar.bar_format = "{l_bar}{bar}| {n:#.02g}/{total:#.02g}"
+
+        # Add func to update with t, not dt
+        pbar.progress = lambda t: pbar.update(t - pbar.n)
+
+        return pbar
 
 
     def _get_initial_condition(self) -> np.ndarray:

--- a/src/qm_sim/hamiltonian/temporal_derivative/crank_nicolson.py
+++ b/src/qm_sim/hamiltonian/temporal_derivative/crank_nicolson.py
@@ -21,6 +21,11 @@ class CrankNicolson(BaseTemporalDerivative):
     stable = True
     name = "crank-nicolson"
 
+    def __init__(self, H: "Hamiltonian", v_0: np.ndarray = None, dt: float = None):
+        if H.ndim != 1:
+            raise ValueError("Crank-Nicolson solver only supports 1D systems")
+        super().__init__(H, v_0, dt)
+
     def iterate(self, t_final: float, dt_storage: float = None):
 
         dt = self.dt

--- a/src/qm_sim/hamiltonian/temporal_derivative/crank_nicolson.py
+++ b/src/qm_sim/hamiltonian/temporal_derivative/crank_nicolson.py
@@ -1,10 +1,18 @@
 import numpy as np
 from scipy.sparse.linalg import spsolve
+from scipy.sparse import dia_matrix
 from tqdm import tqdm
 
 from ...nature_constants import h_bar
 from .base import BaseTemporalDerivative
 
+
+def I_plus_cH(a: complex, H: dia_matrix) -> dia_matrix:
+    out = H.copy()
+    out.data *= a
+    zero_ind = list(out.offsets).index(0)
+    out.data[zero_ind] += 1
+    return out
 
 class CrankNicolson(BaseTemporalDerivative):
     order = 2
@@ -15,26 +23,29 @@ class CrankNicolson(BaseTemporalDerivative):
     def iterate(self, t: float, dt_storage: float = None):
 
         dt = self.dt
-        H0 = self.H
+        H = self.H
         prefactor = dt/(2j * h_bar)
-        H = prefactor * H0
         Vt = self.Vt
         tn = 0
 
-        # Unity "matrix" (in a nice format for our )
-        I = np.ones(self.H0.N).flatten()
+        I = np.ones(H.N).flatten()
 
+        Hn = prefactor*H(tn)
         psi_n = self.psi_0
+
         pbar = tqdm(desc="Crank-Nicholson solver", total=t, disable=not self.H0.verbose)
         while tn < t:
 
-            # psi^n+1 = psi^n-1 + dt/2*(F^n + F^n-1)
+            # psi^n+1 = psi^n + dt/2*(F^n+1 + F^n)
             # F^n = 1/ihbar * H^n @ psi^n
-            # H^n = H0 + V^n
+            # => psi^n+1 = psi^n + dt/2ihbar*(H^n+1 @ psi^n+1 + H^n @ psi^n)
+            # (I - dt/2ihbar*(H^n+1) @ psi^n+1 = (I + dt/2ihbar*H^n) @ psi^n
 
-            Hn = prefactor * H0(t)
 
-            psi_n = spsolve(Hn - I, (H + I) @ psi_n)
+            psi_n = spsolve(
+                I_plus_cH(-prefactor, H(t + dt)), 
+                I_plus_cH(prefactor, H(t)) @ psi_n,
+                )
 
             tn += dt
             H = Hn

--- a/src/qm_sim/hamiltonian/temporal_derivative/crank_nicolson.py
+++ b/src/qm_sim/hamiltonian/temporal_derivative/crank_nicolson.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scipy.sparse.linalg import spsolve
+from scipy.linalg import solve_banded
 from scipy.sparse import dia_matrix
 from tqdm import tqdm
 
@@ -7,8 +7,9 @@ from ...nature_constants import h_bar
 from .base import BaseTemporalDerivative
 
 
-def I_plus_cH(a: complex, H: dia_matrix) -> dia_matrix:
-    out = H.copy()
+def I_plus_aH(a: complex, H: dia_matrix) -> dia_matrix:
+    """Return I + aH, where `I` is the unit matrix and a is `a` constant"""
+    out = H.copy().astype(np.complex128)
     out.data *= a
     zero_ind = list(out.offsets).index(0)
     out.data[zero_ind] += 1
@@ -20,39 +21,41 @@ class CrankNicolson(BaseTemporalDerivative):
     stable = True
     name = "crank-nicolson"
 
-    def iterate(self, t: float, dt_storage: float = None):
+    def iterate(self, t_final: float, dt_storage: float = None):
 
         dt = self.dt
         H = self.H
         prefactor = dt/(2j * h_bar)
-        Vt = self.Vt
+
         tn = 0
+        psi_n = self.v_0
 
-        I = np.ones(H.N).flatten()
+        t = [tn]
+        psi = [psi_n]
 
-        Hn = prefactor*H(tn)
-        psi_n = self.psi_0
+        with self.tqdm(t_final) as pbar:
+            while tn < t_final:
 
-        pbar = tqdm(desc="Crank-Nicholson solver", total=t, disable=not self.H0.verbose)
-        while tn < t:
+                # psi^n+1 = psi^n + dt/2*(F^n+1 + F^n)
+                # F^n = 1/ihbar * H^n @ psi^n
+                # => psi^n+1 = psi^n + dt/2ihbar*(H^n+1 @ psi^n+1 + H^n @ psi^n)
+                # (I - dt/2ihbar*(H^n+1) @ psi^n+1 = (I + dt/2ihbar*H^n) @ psi^n
 
-            # psi^n+1 = psi^n + dt/2*(F^n+1 + F^n)
-            # F^n = 1/ihbar * H^n @ psi^n
-            # => psi^n+1 = psi^n + dt/2ihbar*(H^n+1 @ psi^n+1 + H^n @ psi^n)
-            # (I - dt/2ihbar*(H^n+1) @ psi^n+1 = (I + dt/2ihbar*H^n) @ psi^n
+                lhs = I_plus_aH(-prefactor, H(tn + dt))
+                rhs = I_plus_aH(prefactor, H(tn)) @ psi_n
+                
+                # Reformulate the solve_banded function in terms of the dia_matrix class
+                psi_n = solve_banded(
+                    (-lhs.offsets[0], lhs.offsets[-1]),
+                    lhs.data[::-1, :],
+                    rhs,
+                    )
 
+                pbar.update(dt)
+                tn += dt
 
-            psi_n = spsolve(
-                I_plus_cH(-prefactor, H(t + dt)), 
-                I_plus_cH(prefactor, H(t)) @ psi_n,
-                )
-
-            tn += dt
-            H = Hn
-
-            # store data every `dt_storage` seconds
-            if tn // dt_storage > len(self.psi):
-                self.psi.append(psi_n)
-                self.t.append(tn)
-                self.V.append(Vt(tn))
-            pbar.update(tn)
+                # store data every `dt_storage` seconds
+                if tn // dt_storage > len(psi):
+                    psi.append(psi_n)
+                    t.append(tn)
+        return np.array(t), np.array(psi)

--- a/src/qm_sim/hamiltonian/temporal_derivative/leapfrog.py
+++ b/src/qm_sim/hamiltonian/temporal_derivative/leapfrog.py
@@ -26,9 +26,9 @@ class Leapfrog(BaseTemporalDerivative):
         psi_1 = psi_half + dt / (2j*h_bar) * (H(dt/2) @ psi_half)
 
         steps = 0
-        tn = 0
+        tn = dt/2
 
-        psi = [psi_0.reshape(self.H.shape)]
+        psi = [psi_1.reshape(self.H.shape)]
         t = [tn]
         with self.tqdm(t_final) as pbar:
             while tn < t_final:
@@ -38,8 +38,7 @@ class Leapfrog(BaseTemporalDerivative):
                 # F^n = 1/ihbar * H^n @ psi^n
                 # H^n = H0 + V^n
 
-                psi_2 = H(tn) @ (2*dt / (1j*h_bar) * psi_1) + psi_0
-
+                psi_2 = 2*dt / (1j*h_bar) * (H(tn) @ psi_1) + psi_0
                 psi_0, psi_1 = psi_1, psi_2
 
                 pbar.update(dt)
@@ -47,6 +46,6 @@ class Leapfrog(BaseTemporalDerivative):
 
                 # store data every `dt_storage` seconds
                 if tn // dt_storage > len(psi):
-                    psi.append(psi_1.reshape(self.H.shape))
+                    psi.append(psi_0.reshape(self.H.shape))
                     t.append(tn)
         return np.array(t), np.array(psi)

--- a/src/qm_sim/hamiltonian/temporal_derivative/leapfrog.py
+++ b/src/qm_sim/hamiltonian/temporal_derivative/leapfrog.py
@@ -30,8 +30,7 @@ class Leapfrog(BaseTemporalDerivative):
 
         psi = [psi_0.reshape(self.H.shape)]
         t = [tn]
-        with tqdm(desc="Leapfrog solver", total=t_final, disable=not self.H.verbose) as pbar:
-            pbar.bar_format = "{l_bar}{bar}| {n:#.02g}/{total:#.02g}"
+        with self.tqdm(t_final) as pbar:
             while tn < t_final:
                 steps += 1
 
@@ -43,8 +42,8 @@ class Leapfrog(BaseTemporalDerivative):
 
                 psi_0, psi_1 = psi_1, psi_2
 
-                tn += dt
                 pbar.update(dt)
+                tn += dt
 
                 # store data every `dt_storage` seconds
                 if tn // dt_storage > len(psi):

--- a/src/qm_sim/hamiltonian/temporal_derivative/scipy_solvers.py
+++ b/src/qm_sim/hamiltonian/temporal_derivative/scipy_solvers.py
@@ -11,7 +11,6 @@ class ScipySolver(BaseTemporalDerivative):
     _skip_registration = True
 
     def iterate(self, t_final: float, dt_storage: float = None) -> tuple[np.ndarray, np.ndarray]:
-        if self.H.verbose:
         v_0 = self.v_0.astype(np.complex128).flatten()
         
         pbar = tqdm(desc=self.name + " solver", total=t_final, disable=not self.H.verbose)

--- a/src/qm_sim/hamiltonian/temporal_derivative/scipy_solvers.py
+++ b/src/qm_sim/hamiltonian/temporal_derivative/scipy_solvers.py
@@ -13,14 +13,13 @@ class ScipySolver(BaseTemporalDerivative):
     def iterate(self, t_final: float, dt_storage: float = None) -> tuple[np.ndarray, np.ndarray]:
         v_0 = self.v_0.astype(np.complex128).flatten()
         
-        pbar = tqdm(desc=self.name + " solver", total=t_final, disable=not self.H.verbose)
-        pbar.bar_format = "{l_bar}{bar}| {n:#.02g}/{total:#.02g}"
+        pbar = self.tqdm(t_final)
 
         # Precalculate the coefficient for negligible speedup
         i_hbar_inv = 1 / (1j*h_bar)
 
         def ode_fun(t, y):
-            pbar.update(t - pbar.n)
+            pbar.progress(t)
             return (self.H(t) @ y) * i_hbar_inv
 
         sol = solve_ivp(

--- a/tests/test_hamiltonian.py
+++ b/tests/test_hamiltonian.py
@@ -90,54 +90,55 @@ def test_temporal():
     t_end = 10e-15
     dt = 1e-17
 
-    H1 = Hamiltonian(N, L, m, temporal_scheme="leapfrog")
-    H2 = Hamiltonian(N, L, m, temporal_scheme="scipy-DOP853")
-
-    H2._temporal_solver.v_0 = H1._temporal_solver.v_0.copy()
-
+    H = []
+    schemes = ["leapfrog", "crank-nicolson", "scipy-Runge-Kutta 3(2)", "scipy-DOP853"]
+    for scheme in schemes:
+        H.append(Hamiltonian(N, L, m, temporal_scheme=scheme))
 
     z = np.linspace(-L[0]/2, L[0]/2, N[0])
     Vt = lambda t: 6*z**2 + 3*z*np.abs(z)*np.sin(4e15*t)
-    H1.set_potential(Vt)
-    H2.set_potential(Vt)
+    for Hi in H:
+        Hi.set_potential(Vt)
 
-    t1, psi1 = H1.temporal_evolution(t_end, dt)
-    t2, psi2 = H2.temporal_evolution(t_end, dt)
-    assert np.allclose(t1, t2)
-
-    psi1 = abs(psi1)**2
-    psi1 = psi1.real
-    psi2 = abs(psi2)**2
-    psi2 = psi2.real
+    _, _psi_0 = H[0].eigen(2)
+    psi_0 = 2**0-5 * (_psi_0[0, :] + _psi_0[1, :])
+    t = []
+    psi = []
+    for Hi in H:
+        ti, psii = Hi.temporal_evolution(t_end, dt, psi_0)
+        t.append(ti)
+        psi.append((abs(psii)**2).real)
 
     fig, (ax1, ax2) = plt.subplots(2, 1, sharex=True)
 
-    V = np.array([Vt(tn) for tn in t1])
+    V = np.array([Vt(tn) for tn in t[0]])
 
-    ln_psi1, = ax1.plot(z / 1e-9, psi1[0, :])
-    ln_psi2, = ax1.plot(z / 1e-9, psi2[0, :])
+    psi_plots = []
+    for psii in psi:
+        ln_psi, = ax1.plot(z / 1e-9, psii[0, :])
+        psi_plots.append(ln_psi)
     ln_V, = ax2.plot(z / 1e-9, V[0, :] / const.e_0)
 
     def init():
         ax1.set_title(f"$|\Psi|^2$")
         ax1.set_xlabel("z [nm]")
-        ax1.legend([H1._temporal_solver.name, H2._temporal_solver.name])
+        ax1.legend(schemes)
         ax2.set_title("Potential [eV]")
         ax2.set_xlabel("z [nm]")
-        ax1.set_ylim(0, np.max(psi1) * 1.1)
+        ax1.set_ylim(0, np.max(psi[0]) * 1.1)
         ax2.set_ylim(np.min(V / const.e_0), np.max(V / const.e_0))
         fig.tight_layout()
-        return ln_psi1, ln_psi2, ln_V,
+        return *psi_plots, ln_V,
 
     def frames():
-        for n in range(psi1.shape[0]):
-            yield psi1[n, :], psi2[n, :], V[n, :]
+        for n in range(psi[0].shape[0]):
+            yield *[psii[n, :] for psii in psi], V[n, :]
 
     def update(data):
-        ln_psi1.set_data(z / 1e-9, data[0])
-        ln_psi2.set_data(z / 1e-9, data[1])
-        ln_V.set_data(z / 1e-9, data[2] / const.e_0)
-        return ln_psi1, ln_psi2, ln_V,
+        for i, psi_plot in enumerate(psi_plots):
+            psi_plot.set_data(z / 1e-9, data[i])
+        ln_V.set_data(z / 1e-9, data[-1] / const.e_0)
+        return *psi_plots, ln_V,
     
     ani = FuncAnimation(fig, update, frames=frames, init_func=init, blit=False, interval=50)
     plt.show()


### PR DESCRIPTION
Fixes #5

Correctly implement Crank-Nicolson

Fix leapfrog, but I'm not entirely sure if the state and time that is stored is correct.
Fixed a bug/typo where the internal dt of the solver was set to the requested data storage dt, which is outside the stable region of the solver.
I just remembered, there is a better estimator for abs(psi)^2 for the leapfrog method than using abs(psi_n)^2, should implement that..

Add a tqdm member to the temporal solver, to have consistent logging format between solvers

Include more solvers in the `test_temporal` visualisation. This includes leapfrog, which is a bit ahead of the rest due to the initial condition- and time-shift
